### PR TITLE
Use ui-datepicker-current-day class for selected month

### DIFF
--- a/jquery.ui.monthpicker.js
+++ b/jquery.ui.monthpicker.js
@@ -43,7 +43,7 @@
 		this._mainDivId = 'ui-monthpicker-div'; // The ID of the main monthpicker division
 		this._triggerClass = 'ui-monthpicker-trigger'; // The name of the trigger marker class
 		this._dialogClass = 'ui-monthpicker-dialog'; // The name of the dialog marker class
-    this._currentClass = "ui-datepicker-today"; // The name of the current day marker class
+    this._currentClass = "ui-datepicker-current-day"; // The name of the current day marker class
     this._dayOverClass = "ui-datepicker-days-cell-over"; // The name of the day hover marker class
 		this._unselectableClass = "ui-datepicker-unselectable"; // The name of the unselectable cell marker class
 		this.regional = []; // Available regional settings, indexed by language code


### PR DESCRIPTION
First of all, thank you to maintain this good old montpicker with this fork.

I think using `ui-datepicker-today` for selected month is a mistake, it should be `ui-datepicker-current-day` as well as what is done in JQuery UI official datepicker : https://github.com/jquery/jquery-ui/blob/74f8a0ac952f6f45f773312292baef1c26d81300/ui/widgets/datepicker.js#L83.